### PR TITLE
Ensure agent system prompt includes full tool awareness

### DIFF
--- a/REF DOCS/System Prompt.txt
+++ b/REF DOCS/System Prompt.txt
@@ -1,0 +1,17 @@
+You are BrowserOS Assistant, a senior software engineer agent operating inside the browser sidecar runtime.
+
+Core behavior:
+- Prefer using tools when you need fresh page state, web evidence, or browser actions.
+- Be explicit, safe, and concise.
+- Do not invent tool output.
+
+Tool usage format examples:
+- Use `read_page` to inspect structure and interactive refs before acting.
+- Use `find` to locate controls by natural language.
+- Use `get_page_text` to extract article text.
+- Use `search_web` to fetch external evidence.
+- Use `navigate` to open URLs or move history.
+- Use `tabs_create` to create/activate/close/list/group tabs.
+- Use `computer` for low-level actions (click/type/scroll/screenshot).
+- Use `form_input` to fill forms by ref_id.
+- Use `todo_write` to keep task progress updated.

--- a/REF DOCS/tools.json
+++ b/REF DOCS/tools.json
@@ -1,0 +1,26 @@
+### read_page
+Read the current page structure and interactive elements.
+
+### find
+Find matching interactive elements on the current page.
+
+### get_page_text
+Extract text content from the current page.
+
+### search_web
+Search the web for external information.
+
+### navigate
+Navigate the current tab to a URL or move through history.
+
+### tabs_create
+Manage browser tabs: create, activate, close, list, group, or ungroup.
+
+### computer
+Perform low-level browser interactions such as click, type, scroll, or screenshot.
+
+### form_input
+Fill one or more form fields by ref_id.
+
+### todo_write
+Write task progress notes for the current run.

--- a/sidecar/src/agent/prompt-loader.spec.ts
+++ b/sidecar/src/agent/prompt-loader.spec.ts
@@ -1,0 +1,42 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { loadPromptSpecs } from "./prompt-loader";
+
+describe("loadPromptSpecs", () => {
+  it("appends tool spec into the system prompt when tool names are missing", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "prompt-loader-"));
+    const systemPromptPath = "System Prompt.txt";
+    const toolsPath = "tools.json";
+
+    await Promise.all([
+      writeFile(join(rootDir, systemPromptPath), "You are an assistant."),
+      writeFile(join(rootDir, toolsPath), "### read_page\nRead page")
+    ]);
+
+    const specs = await loadPromptSpecs({ rootDir, systemPromptPath, toolsPath });
+
+    expect(specs.systemPrompt).toContain("## Available tools");
+    expect(specs.systemPrompt).toContain("### read_page");
+    expect(specs.toolNames).toEqual(["read_page"]);
+  });
+
+  it("keeps the original system prompt when all tool names are already present", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "prompt-loader-"));
+    const systemPromptPath = "System Prompt.txt";
+    const toolsPath = "tools.json";
+    const systemPrompt = "Use read_page before acting.";
+
+    await Promise.all([
+      writeFile(join(rootDir, systemPromptPath), systemPrompt),
+      writeFile(join(rootDir, toolsPath), "### read_page\nRead page")
+    ]);
+
+    const specs = await loadPromptSpecs({ rootDir, systemPromptPath, toolsPath });
+
+    expect(specs.systemPrompt).toBe(systemPrompt);
+  });
+});

--- a/sidecar/src/agent/prompt-loader.ts
+++ b/sidecar/src/agent/prompt-loader.ts
@@ -40,11 +40,17 @@ export async function loadPromptSpecs(options: PromptLoaderOptions = {}): Promis
   ]);
 
   const toolNames = extractToolNames(toolsSpec);
+  const normalizedSystemPrompt = systemPrompt.toLowerCase();
+  const missingTools = toolNames.filter((toolName) => !normalizedSystemPrompt.includes(toolName));
+  const systemPromptWithTools =
+    missingTools.length === 0
+      ? systemPrompt
+      : `${systemPrompt.trimEnd()}\n\n## Available tools\n${toolsSpec.trim()}\n`;
 
   return {
-    systemPrompt,
+    systemPrompt: systemPromptWithTools,
     toolsSpec,
     toolNames,
-    policy: compilePromptPolicy(systemPrompt, toolNames)
+    policy: compilePromptPolicy(systemPromptWithTools, toolNames)
   };
 }


### PR DESCRIPTION
### Motivation

- Make the agent's system prompt reliably aware of the runtime tools so prompts and policies reflect the actual toolset.
- Prevent situations where the system prompt omits canonical tool names that the loader and policy compiler expect.

### Description

- Add default prompt assets under `REF DOCS/` (`System Prompt.txt` and `tools.json`) that document tool usage and include canonical `### tool_name` entries.
- Update `loadPromptSpecs` to detect when declared tool names are missing from the base system prompt and append an `## Available tools` section containing `tools.json` in that case.
- Ensure the policy is compiled against the effective system prompt (original or appended) by passing the possibly-augmented prompt to `compilePromptPolicy`.
- Add unit tests at `sidecar/src/agent/prompt-loader.spec.ts` covering both the append-path and the no-op path.

### Testing

- Ran the unit tests with `npm test -- sidecar/src/agent/prompt-loader.spec.ts`, and both tests passed.
- Attempted repository typecheck with `npm run typecheck`, which failed due to a missing `tsconfig.task2.json` in this repo configuration.
- Verified the new files load and that `loadPromptSpecs` returns `toolNames`, `toolsSpec`, the effective `systemPrompt`, and a compiled `policy` during tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9c18e1c988325a5397a37dee00084)