### PR TITLE
Validate REF DOCS declared tools vs sidecar catalog and improve prompt loader parsing

### DIFF
--- a/sidecar/src/agent/orchestrator.ts
+++ b/sidecar/src/agent/orchestrator.ts
@@ -21,7 +21,7 @@ import {
 } from "../policy/response-validator";
 import { createMemoryStore } from "./memory-store";
 import { loadPromptSpecs, type PromptLoaderOptions } from "./prompt-loader";
-import { buildToolSchemaCatalog } from "./tool-schema";
+import { buildToolSchemaCatalog, findToolCatalogMismatches } from "./tool-schema";
 import type {
   AgentMemoryStore,
   AgentOrchestrator,
@@ -1079,6 +1079,14 @@ export async function createOrchestrator(options: OrchestratorOptions): Promise<
       }
 
       const fullToolCatalog = buildToolSchemaCatalog(promptSpecs.toolNames);
+      const toolingMismatches = findToolCatalogMismatches(promptSpecs.declaredTools, fullToolCatalog);
+      if (toolingMismatches.length > 0) {
+        throw Object.assign(new Error(`Tool definitions from REF DOCS mismatch sidecar implementation: ${toolingMismatches.join(", ")}`), {
+          code: "TOOLING_MISMATCH",
+          retryable: false
+        });
+      }
+
       let toolCatalog = fullToolCatalog.filter((tool) => tool.name !== "todo_write");
       if (!funcCallingEnabled) {
         toolCatalog = [];

--- a/sidecar/src/agent/prompt-loader.test.ts
+++ b/sidecar/src/agent/prompt-loader.test.ts
@@ -1,0 +1,55 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadPromptSpecs } from "./prompt-loader";
+
+const dirsToDelete: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(dirsToDelete.splice(0).map(async (dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createPromptFiles(systemPrompt: string, toolsSpec: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "prompt-loader-"));
+  dirsToDelete.push(dir);
+  await writeFile(join(dir, "System Prompt.txt"), systemPrompt, "utf8");
+  await writeFile(join(dir, "tools.json"), toolsSpec, "utf8");
+  return dir;
+}
+
+describe("loadPromptSpecs", () => {
+  it("extracts declared tools and schemas from JSON function definitions", async () => {
+    const rootDir = await createPromptFiles(
+      "System prompt",
+      JSON.stringify({
+        tools: [
+          { type: "function", function: { name: "Navigate", parameters: { type: "object", properties: { mode: { type: "string" } }, required: ["mode"] } } },
+          { type: "function", function: { name: "read_page", input_schema: { type: "object", properties: { depth: { type: "number" } } } } },
+          { metadata: { name: "not_a_tool" } }
+        ]
+      })
+    );
+
+    const specs = await loadPromptSpecs({ rootDir, systemPromptPath: "System Prompt.txt", toolsPath: "tools.json" });
+
+    expect(specs.toolNames).toEqual(["navigate", "read_page"]);
+    expect(specs.declaredTools).toHaveLength(2);
+    expect(specs.declaredTools[0]?.parameters).toEqual({
+      type: "object",
+      properties: { mode: { type: "string" } },
+      required: ["mode"]
+    });
+  });
+
+  it("falls back to heading parsing when tool spec is not JSON", async () => {
+    const rootDir = await createPromptFiles("System prompt", ["### navigate", "details", "### search_web", "### read_page"].join("\n"));
+
+    const specs = await loadPromptSpecs({ rootDir, systemPromptPath: "System Prompt.txt", toolsPath: "tools.json" });
+
+    expect(specs.toolNames).toEqual(["navigate", "search_web", "read_page"]);
+    expect(specs.declaredTools).toEqual([{ name: "navigate" }, { name: "search_web" }, { name: "read_page" }]);
+  });
+});

--- a/sidecar/src/agent/prompt-loader.ts
+++ b/sidecar/src/agent/prompt-loader.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
-import type { PromptSpecs } from "./types";
+import type { PromptDeclaredTool, PromptSpecs } from "./types";
 import { compilePromptPolicy } from "../policy/prompt-policy-compiler";
 
 export interface PromptLoaderOptions {
@@ -12,21 +12,83 @@ export interface PromptLoaderOptions {
 
 const DEFAULT_SYSTEM_PROMPT_PATH = "REF DOCS/System Prompt.txt";
 const DEFAULT_TOOLS_PATH = "REF DOCS/tools.json";
-
 const TOOL_NAME_PATTERN = /^###\s+([a-z_]+)\s*$/gim;
 
-function extractToolNames(toolsSpec: string): string[] {
-  const names = new Set<string>();
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseJsonDeclaredTools(toolsSpec: string): PromptDeclaredTool[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(toolsSpec);
+  } catch {
+    return [];
+  }
+
+  const candidates =
+    Array.isArray(parsed)
+      ? parsed
+      : isRecord(parsed) && Array.isArray(parsed.tools)
+        ? parsed.tools
+        : isRecord(parsed) && Array.isArray(parsed.functions)
+          ? parsed.functions
+          : [];
+
+  const tools: PromptDeclaredTool[] = [];
+  const seen = new Set<string>();
+
+  for (const rawEntry of candidates) {
+    if (!isRecord(rawEntry)) {
+      continue;
+    }
+
+    const functionEntry = rawEntry.type === "function" && isRecord(rawEntry.function) ? rawEntry.function : rawEntry;
+    const name = typeof functionEntry.name === "string" ? functionEntry.name.trim().toLowerCase() : "";
+    if (!name || seen.has(name)) {
+      continue;
+    }
+
+    const parameters = isRecord(functionEntry.parameters)
+      ? (functionEntry.parameters as Record<string, unknown>)
+      : isRecord(functionEntry.input_schema)
+        ? (functionEntry.input_schema as Record<string, unknown>)
+        : undefined;
+
+    seen.add(name);
+    tools.push({
+      name,
+      ...(parameters ? { parameters: JSON.parse(JSON.stringify(parameters)) as PromptDeclaredTool["parameters"] } : {})
+    });
+  }
+
+  return tools;
+}
+
+function parseHeadingDeclaredTools(toolsSpec: string): PromptDeclaredTool[] {
+  const tools: PromptDeclaredTool[] = [];
+  const seen = new Set<string>();
+
   TOOL_NAME_PATTERN.lastIndex = 0;
   let match: RegExpExecArray | null = TOOL_NAME_PATTERN.exec(toolsSpec);
   while (match) {
-    const value = match[1]?.trim().toLowerCase();
-    if (value) {
-      names.add(value);
+    const toolName = match[1]?.trim().toLowerCase();
+    if (toolName && !seen.has(toolName)) {
+      seen.add(toolName);
+      tools.push({ name: toolName });
     }
     match = TOOL_NAME_PATTERN.exec(toolsSpec);
   }
-  return [...names];
+
+  return tools;
+}
+
+function extractDeclaredTools(toolsSpec: string): PromptDeclaredTool[] {
+  const jsonTools = parseJsonDeclaredTools(toolsSpec);
+  if (jsonTools.length > 0) {
+    return jsonTools;
+  }
+  return parseHeadingDeclaredTools(toolsSpec);
 }
 
 export async function loadPromptSpecs(options: PromptLoaderOptions = {}): Promise<PromptSpecs> {
@@ -34,17 +96,16 @@ export async function loadPromptSpecs(options: PromptLoaderOptions = {}): Promis
   const systemPromptPath = resolve(rootDir, options.systemPromptPath ?? DEFAULT_SYSTEM_PROMPT_PATH);
   const toolsPath = resolve(rootDir, options.toolsPath ?? DEFAULT_TOOLS_PATH);
 
-  const [systemPrompt, toolsSpec] = await Promise.all([
-    readFile(systemPromptPath, "utf8"),
-    readFile(toolsPath, "utf8")
-  ]);
+  const [systemPrompt, toolsSpec] = await Promise.all([readFile(systemPromptPath, "utf8"), readFile(toolsPath, "utf8")]);
 
-  const toolNames = extractToolNames(toolsSpec);
+  const declaredTools = extractDeclaredTools(toolsSpec);
+  const toolNames = declaredTools.map((tool) => tool.name);
 
   return {
     systemPrompt,
     toolsSpec,
     toolNames,
+    declaredTools,
     policy: compilePromptPolicy(systemPrompt, toolNames)
   };
 }

--- a/sidecar/src/agent/tool-schema.test.ts
+++ b/sidecar/src/agent/tool-schema.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { buildToolSchemaCatalog, findToolCatalogMismatches } from "./tool-schema";
+
+describe("findToolCatalogMismatches", () => {
+  it("reports missing declared tools", () => {
+    const catalog = buildToolSchemaCatalog([]);
+    const mismatches = findToolCatalogMismatches([{ name: "navigate" }, { name: "comet_magic" }], catalog);
+
+    expect(mismatches).toContain("missing:comet_magic");
+    expect(mismatches).not.toContain("missing:navigate");
+  });
+
+  it("reports parameter and required field mismatches", () => {
+    const catalog = buildToolSchemaCatalog(["navigate"]);
+    const mismatches = findToolCatalogMismatches(
+      [
+        {
+          name: "navigate",
+          parameters: {
+            type: "object",
+            properties: {
+              mode: { type: "string" },
+              unexpected: { type: "string" }
+            },
+            required: ["mode", "unexpected"]
+          }
+        }
+      ],
+      catalog
+    );
+
+    expect(mismatches).toContain("param:navigate.unexpected");
+    expect(mismatches).toContain("required:navigate.unexpected");
+  });
+});

--- a/sidecar/src/agent/tool-schema.ts
+++ b/sidecar/src/agent/tool-schema.ts
@@ -1,5 +1,5 @@
 import type { JsonObject } from "../../../shared/src/transport";
-import type { AgentToolSchemaEntry } from "./types";
+import type { AgentToolSchemaEntry, PromptDeclaredTool } from "./types";
 
 const TOOL_SCHEMAS: AgentToolSchemaEntry[] = [
   {
@@ -142,6 +142,56 @@ const TOOL_SCHEMAS: AgentToolSchemaEntry[] = [
 
 function cloneParameters(parameters: JsonObject): JsonObject {
   return JSON.parse(JSON.stringify(parameters)) as JsonObject;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}
+
+function asStringSet(value: unknown): Set<string> {
+  return new Set(Array.isArray(value) ? value.filter((item): item is string => typeof item === "string").map((item) => item.toLowerCase()) : []);
+}
+
+export function findToolCatalogMismatches(declaredTools: PromptDeclaredTool[], catalog: AgentToolSchemaEntry[]): string[] {
+  const catalogByName = new Map(catalog.map((entry) => [entry.name.toLowerCase(), entry]));
+  const mismatches: string[] = [];
+
+  for (const declared of declaredTools) {
+    const implemented = catalogByName.get(declared.name.toLowerCase());
+    if (!implemented) {
+      mismatches.push(`missing:${declared.name}`);
+      continue;
+    }
+
+    if (!declared.parameters) {
+      continue;
+    }
+
+    const declaredParameters = asRecord(declared.parameters);
+    const implementedParameters = asRecord(implemented.parameters);
+    const declaredProps = asRecord(declaredParameters?.properties);
+    const implementedProps = asRecord(implementedParameters?.properties);
+
+    if (!declaredProps || !implementedProps) {
+      continue;
+    }
+
+    for (const propertyName of Object.keys(declaredProps)) {
+      if (!(propertyName in implementedProps)) {
+        mismatches.push(`param:${declared.name}.${propertyName}`);
+      }
+    }
+
+    const declaredRequired = asStringSet(declaredParameters?.required);
+    const implementedRequired = asStringSet(implementedParameters?.required);
+    for (const requiredName of declaredRequired) {
+      if (!implementedRequired.has(requiredName)) {
+        mismatches.push(`required:${declared.name}.${requiredName}`);
+      }
+    }
+  }
+
+  return mismatches;
 }
 
 export function buildToolSchemaCatalog(toolNames: string[]): AgentToolSchemaEntry[] {

--- a/sidecar/src/agent/types.ts
+++ b/sidecar/src/agent/types.ts
@@ -11,10 +11,16 @@ import type {
 import type { PromptPolicy } from "../policy/types";
 export type { PromptPolicy } from "../policy/types";
 
+export interface PromptDeclaredTool {
+  name: string;
+  parameters?: JsonObject;
+}
+
 export interface PromptSpecs {
   systemPrompt: string;
   toolsSpec: string;
   toolNames: string[];
+  declaredTools: PromptDeclaredTool[];
   policy: PromptPolicy;
 }
 


### PR DESCRIPTION
### Motivation

- Ensure the tools declared in REF DOCS match the sidecar's implemented tool catalog to prevent runtime function-calling mismatches. 
- Improve robustness of prompt loading by extracting declared tool metadata from both JSON function definitions and markdown headings. 

### Description

- Added `PromptDeclaredTool` to `types.ts` and extended `PromptSpecs` to include `declaredTools`. 
- Enhanced `prompt-loader.ts` to parse declared tools from JSON or from `###` headings and to return `declaredTools` alongside `toolNames` and `policy`. 
- Implemented `findToolCatalogMismatches` in `tool-schema.ts` to compare REF DOCS-declared tool names and parameter schemas against the sidecar `TOOL_SCHEMAS`, reporting missing tools, missing parameters, and missing required fields. 
- Wired mismatch checking into the orchestrator (`orchestrator.ts`) to throw a `TOOLING_MISMATCH` error when any mismatches are detected. 
- Added unit tests: `prompt-loader.test.ts` to verify JSON and heading parsing and `tool-schema.test.ts` to verify mismatch detection. 

### Testing

- Ran unit tests for the modified modules with `vitest`, including `prompt-loader.test.ts` and `tool-schema.test.ts`, and the new tests passed. 
- Existing test suites covering orchestrator interactions were exercised locally and did not report regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b666ceb88325bf1f964acd041ec6)