### PR TITLE
Add tool schema audit script, required-tools list, and tests

### DIFF
--- a/TOOL_TESTS.md
+++ b/TOOL_TESTS.md
@@ -1,0 +1,34 @@
+# Tool Access Checks
+
+Run these checks directly instead of relying on static notes.
+
+## 1) Sidecar tool schema audit
+
+```bash
+npm run audit:tools
+```
+
+Expected: `"ok": true` and empty `missing` array.
+
+## 2) Unit tests for audit rules
+
+```bash
+npm run test:tool-audit
+```
+
+Expected: all tests pass.
+
+## 3) Infra/MCP runtime checks (agent execution)
+
+Run in an agent session and verify each tool invocation succeeds end-to-end:
+
+- `exec_command`
+- `write_stdin`
+- `update_plan`
+- `list_mcp_resources`
+- `list_mcp_resource_templates`
+- `read_mcp_resource` (valid resource when available; otherwise verify error path)
+- `mcp__browser_tools__run_playwright_script`
+- `mcp__browser_tools__open_image_artifact`
+- `view_image`
+- `mcp__make_pr__make_pr`

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "format:check": "tsc --noEmit -p tsconfig.task2.json",
     "test:unit": "vitest run tests/cdp/frame-registry.spec.ts tests/cdp/session-registry.spec.ts",
     "test:integration": "vitest run tests/cdp/target-event-router.spec.ts",
-    "test:e2e": "vitest run tests/e2e/*.spec.ts"
+    "test:e2e": "vitest run tests/e2e/*.spec.ts",
+    "audit:tools": "tsx scripts/audit-tool-access.mjs",
+    "test:tool-audit": "vitest run tests/agent/tool-schema-audit.spec.ts"
   },
   "devDependencies": {
     "@types/node": "^25.3.2",

--- a/scripts/audit-tool-access.mjs
+++ b/scripts/audit-tool-access.mjs
@@ -1,0 +1,17 @@
+import { SYSTEM_REQUIRED_TOOL_NAMES, validateRequiredToolSchemas } from "../sidecar/src/agent/tool-schema.ts";
+
+const report = validateRequiredToolSchemas(SYSTEM_REQUIRED_TOOL_NAMES);
+
+const payload = {
+  checked: [...SYSTEM_REQUIRED_TOOL_NAMES],
+  available: report.available,
+  missing: report.missing,
+  ok: report.missing.length === 0,
+  timestamp: new Date().toISOString()
+};
+
+console.log(JSON.stringify(payload, null, 2));
+
+if (!payload.ok) {
+  process.exitCode = 1;
+}

--- a/sidecar/src/agent/tool-schema.ts
+++ b/sidecar/src/agent/tool-schema.ts
@@ -140,8 +140,37 @@ const TOOL_SCHEMAS: AgentToolSchemaEntry[] = [
   }
 ];
 
+export const SYSTEM_REQUIRED_TOOL_NAMES = [
+  "read_page",
+  "find",
+  "get_page_text",
+  "search_web",
+  "navigate",
+  "tabs_create",
+  "computer",
+  "form_input",
+  "todo_write"
+] as const;
+
+export interface ToolSchemaAuditResult {
+  available: string[];
+  missing: string[];
+}
+
 function cloneParameters(parameters: JsonObject): JsonObject {
   return JSON.parse(JSON.stringify(parameters)) as JsonObject;
+}
+
+export function listToolSchemaNames(): string[] {
+  return TOOL_SCHEMAS.map((entry) => entry.name);
+}
+
+export function validateRequiredToolSchemas(requiredToolNames: readonly string[]): ToolSchemaAuditResult {
+  const availableSet = new Set(listToolSchemaNames());
+  const missing = requiredToolNames.filter((toolName) => !availableSet.has(toolName));
+  const available = requiredToolNames.filter((toolName) => availableSet.has(toolName));
+
+  return { available, missing };
 }
 
 export function buildToolSchemaCatalog(toolNames: string[]): AgentToolSchemaEntry[] {

--- a/tests/agent/tool-schema-audit.spec.ts
+++ b/tests/agent/tool-schema-audit.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { buildToolSchemaCatalog, validateRequiredToolSchemas, SYSTEM_REQUIRED_TOOL_NAMES } from "../../sidecar/src/agent/tool-schema";
+
+describe("tool schema audit", () => {
+  it("includes every required tool", () => {
+    const audit = validateRequiredToolSchemas(SYSTEM_REQUIRED_TOOL_NAMES);
+    expect(audit.missing).toEqual([]);
+    expect(audit.available.sort()).toEqual([...SYSTEM_REQUIRED_TOOL_NAMES].sort());
+  });
+
+  it("reports missing tool names", () => {
+    const audit = validateRequiredToolSchemas(["read_page", "nonexistent_tool"]);
+    expect(audit.missing).toEqual(["nonexistent_tool"]);
+    expect(audit.available).toContain("read_page");
+  });
+
+  it("returns cloned parameter objects", () => {
+    const [schema] = buildToolSchemaCatalog(["read_page"]);
+    const originalProperties = schema.parameters.properties as Record<string, unknown>;
+    schema.parameters.properties = { changed: { type: "string" } };
+    const [fresh] = buildToolSchemaCatalog(["read_page"]);
+    const freshProperties = fresh.parameters.properties as Record<string, unknown>;
+    expect(freshProperties.depth).toEqual(originalProperties.depth);
+    expect(freshProperties).not.toEqual(schema.parameters.properties);
+  });
+});


### PR DESCRIPTION
### Motivation

- Ensure the sidecar agent exposes a known set of required tool schemas and provide an automated way to detect regressions.

### Description

- Add `SYSTEM_REQUIRED_TOOL_NAMES` and implement `listToolSchemaNames` and `validateRequiredToolSchemas` in `sidecar/src/agent/tool-schema.ts` to enumerate and validate required tool schemas.
- Add an audit CLI `scripts/audit-tool-access.mjs` that prints a JSON report and exits non-zero when required schemas are missing.
- Add `tests/agent/tool-schema-audit.spec.ts` with unit tests that verify required tools are present, missing-tools reporting, and that `buildToolSchemaCatalog` returns cloned parameter objects.
- Update `package.json` to include `audit:tools` and `test:tool-audit` scripts and add `TOOL_TESTS.md` documenting the checks to run.

### Testing

- Ran `npm run test:tool-audit` which executed `tests/agent/tool-schema-audit.spec.ts` and the tests passed.
- Ran `npm run audit:tools` which prints a JSON payload including `ok: true` and an empty `missing` array when all required schemas are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b7f8b0e48325acfe1f0b67fb0cba)